### PR TITLE
Fix Mac OS Compile

### DIFF
--- a/src/qt/multisenddialog.cpp
+++ b/src/qt/multisenddialog.cpp
@@ -7,6 +7,7 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <boost/lexical_cast.hpp>
+#include <QStyle>
 
 using namespace std;
 using namespace boost;


### PR DESCRIPTION
Fix for -> qt/multisenddialog.cpp:80:25: error: member access into incomplete type 'QStyle' ui->message->style()->polish(ui->message);